### PR TITLE
fix: migrate OpenAIModel to provider API (pydantic-ai 0.4.x)

### DIFF
--- a/src/backend/core/core.py
+++ b/src/backend/core/core.py
@@ -6,6 +6,7 @@ import openai
 import praw
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
 
 from backend.core.consts import AI_MODEL, default_system_prompt
 from backend.db.base import Base
@@ -70,7 +71,10 @@ class SwotAgentDeps:
 
 
 swot_agent = Agent(
-    OpenAIModel(model_name=AI_MODEL, api_key=get_val("OPENAI_API_KEY")),
+    OpenAIModel(
+        model_name=AI_MODEL,
+        provider=OpenAIProvider(api_key=get_val("OPENAI_API_KEY")),
+    ),
     deps_type=SwotAgentDeps,
     result_type=SwotAnalysis,
     system_prompt=default_system_prompt,


### PR DESCRIPTION
## Summary
- `pydantic-ai` 0.4.x removed the `api_key` kwarg from `OpenAIModel.__init__()`
- API key is now passed via `OpenAIProvider(api_key=...)` to the `provider` parameter
- This was the crash blocking every container restart

## Change
`src/backend/core/core.py`:
```python
# before
OpenAIModel(model_name=AI_MODEL, api_key=get_val("OPENAI_API_KEY"))

# after
OpenAIModel(model_name=AI_MODEL, provider=OpenAIProvider(api_key=get_val("OPENAI_API_KEY")))
```

## Test plan
- [ ] Confirm Komodo deploy completes and gunicorn workers stay up
- [ ] Smoke-test an analysis request end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)