### PR TITLE
fix: resolve remaining pydantic-ai 0.4.x breakages and startup errors

### DIFF
--- a/src/backend/core/core.py
+++ b/src/backend/core/core.py
@@ -76,7 +76,7 @@ swot_agent = Agent(
         provider=OpenAIProvider(api_key=get_val("OPENAI_API_KEY")),
     ),
     deps_type=SwotAgentDeps,
-    result_type=SwotAnalysis,
+    output_type=SwotAnalysis,
     system_prompt=default_system_prompt,
     retries=5,
 )

--- a/src/backend/core/tools.py
+++ b/src/backend/core/tools.py
@@ -166,7 +166,7 @@ async def get_reddit_insights(
     return "\n".join(insights)
 
 
-@swot_agent.result_validator
+@swot_agent.output_validator
 def validate_result(
     _ctx: RunContext[SwotAgentDeps], value: SwotAnalysis
 ) -> SwotAnalysis:

--- a/src/backend/settings/consts.py
+++ b/src/backend/settings/consts.py
@@ -3,7 +3,9 @@ import os
 
 from decouple import config
 
-BASE_DIR = os.path.join(os.path.dirname(os.path.dirname("__name__")))
+BASE_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
 BACKEND_DIR = os.path.join(BASE_DIR, "backend")
 FRONTEND_DIR = os.path.join(BASE_DIR, "frontend")
 

--- a/src/frontend/templates/home.html
+++ b/src/frontend/templates/home.html
@@ -4,7 +4,7 @@
     <div class="hero-body">
         <div class="container has-text-centered">
             <div class="hero-icon mb-4">
-                <img src="{{ url_for('static', filename='purple.svg') }}"
+                <img src="{{ url_for('static', path='purple.svg') }}"
                      alt="StrategIQ"
                      style="width: 80px; height: 80px;">
             </div>


### PR DESCRIPTION
## Summary
Four issues found while running locally — all blocking startup:

1. **`result_type` → `output_type`** (`core.py`) — pydantic-ai 0.4.x rename
2. **`result_validator` → `output_validator`** (`tools.py`) — same rename, decorator form
3. **`BASE_DIR` resolved to `""`** (`consts.py`) — was calling `os.path.dirname` on the string literal `"__name__"` instead of `__file__`. All template/static paths were relative to CWD; only worked in Docker because the entrypoint `cd src` first. Fixed to use `os.path.abspath(__file__)` anchored three levels up to `src/`.
4. **`url_for('static', filename=...)` → `path=...`** (`home.html`) — Starlette StaticFiles uses `path`; every other template already did.

## Verified locally
All routes return 200: `/`, `/status`, `/result`, `/static/purple.svg`, `/static/css/pygentic_ai.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)