### PR TITLE
refactor: use pathlib.Path for BASE_DIR, BACKEND_DIR, FRONTEND_DIR

### DIFF
--- a/src/backend/settings/base.py
+++ b/src/backend/settings/base.py
@@ -1,11 +1,13 @@
+from pathlib import Path
+
 from pydantic_settings import BaseSettings
 
 from backend.settings.consts import BACKEND_DIR, FRONTEND_DIR
 
 
 class Settings(BaseSettings):
-    backend_dir: str = BACKEND_DIR
-    frontend_dir: str = FRONTEND_DIR
+    backend_dir: Path = BACKEND_DIR
+    frontend_dir: Path = FRONTEND_DIR
 
     DB_URL: str = "sqlite+aiosqlite:///backend/pygentic_ai.sqlite3"
     DEBUG: bool = False

--- a/src/backend/settings/consts.py
+++ b/src/backend/settings/consts.py
@@ -1,13 +1,11 @@
 import enum
-import os
+from pathlib import Path
 
 from decouple import config
 
-BASE_DIR = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-)
-BACKEND_DIR = os.path.join(BASE_DIR, "backend")
-FRONTEND_DIR = os.path.join(BASE_DIR, "frontend")
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+BACKEND_DIR = BASE_DIR / "backend"
+FRONTEND_DIR = BASE_DIR / "frontend"
 
 
 pg_dialects = [


### PR DESCRIPTION
## Summary
- Replaced `os.path.dirname`/`os.path.join` chains in `consts.py` with `Path(__file__).resolve()` and `/` operator
- Updated `Settings` field types in `base.py` from `str` to `Path` (pydantic v2 won't coerce `Path` → `str` implicitly)
- Removed unused `import os` from `consts.py`
- All downstream consumers (`os.path.join`, Jinja2 `StaticFiles`, `logger.py`) accept `Path` objects natively

🤖 Generated with [Claude Code](https://claude.com/claude-code)